### PR TITLE
fix: align POST URI with spec

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -24,7 +24,7 @@ app.get("/", (req, res) => {
 })
 
 
-app.post('/v1/tlsrpt', (req, res, next) => {
+app.post(['/v1/tls-rpt', '/v1/tlsrpt'], (req, res, next) => {
   getRawBody(req)
     .then(buf => req.get("content-type").endsWith("gzip") ? do_unzip(buf) : buf)
     .then((buf) => buf.toString())

--- a/index.mjs
+++ b/index.mjs
@@ -24,7 +24,7 @@ app.get("/", (req, res) => {
 })
 
 
-app.post('/v1/tls-rpt', (req, res, next) => {
+app.post('/v1/tlsrpt', (req, res, next) => {
   getRawBody(req)
     .then(buf => req.get("content-type").endsWith("gzip") ? do_unzip(buf) : buf)
     .then((buf) => buf.toString())


### PR DESCRIPTION
After running this for a few weeks, I noticed it failing because the URI doesn't match the example in the [spec](https://datatracker.ietf.org/doc/html/rfc8460#section-3.1.2) and elsewhere on the internet. Seems like it's become a de-facto standard